### PR TITLE
Switch to OpenWeather OneCall 3.0 API

### DIFF
--- a/src/L_MsWeather.lua
+++ b/src/L_MsWeather.lua
@@ -915,7 +915,7 @@ local ProviderMap = {
 				return complete
 			end, 
 			update = function()
-				local urltemplate = "https://api.openweathermap.org/data/2.5/onecall?lat=%s&lon=%s&units=%s&lang=%s&appid=%s&exclude=hourly"
+				local urltemplate = "https://api.openweathermap.org/data/3.0/onecall?lat=%s&lon=%s&units=%s&lang=%s&appid=%s&exclude=hourly"
 				local url = string.format(urltemplate, MS.Latitude, MS.Longitude, MS.Units, MS.Language, MS.Key)
 				-- See if user wants forecast, if not eliminate daily from request
 				if MS.ForecastDays == 0 then url = url .. ",daily" end


### PR DESCRIPTION
It appears there are no incompatibilities in the subset of the 2.5 vs 3.0 OneCall APIs used by MultiStationWeather.  The 2.5 API is evidently being deprecated within a few days.  Note that according to OpenWeatherMap, the other 2.5 APIs such as the air quality API are still valid.